### PR TITLE
Add support for larger proxy buffers

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -234,9 +234,6 @@ upstream {{ $upstream_name }} {
 {{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
 {{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) (or $.Env.HSTS "max-age=31536000") }}
 
-{{/* Use larger proxy buffers only when backend sets PROXY_LARGE_BUFFERS=true (e.g. main app) */}}
-{{ $proxy_large_buffers := eq (or (first (groupByKeys $containers "Env.PROXY_LARGE_BUFFERS")) "false") "true" }}
-
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
@@ -347,10 +344,8 @@ server {
 		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ if $proxy_large_buffers }}
 		proxy_buffer_size 16k;
 		proxy_buffers 8 16k;
-		{{ end }}
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -403,11 +398,10 @@ server {
 		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ if $proxy_large_buffers }}
 		proxy_buffer_size 16k;
 		proxy_buffers 8 16k;
 		{{ end }}
-		{{ end }}
+		
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};

--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -234,6 +234,9 @@ upstream {{ $upstream_name }} {
 {{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
 {{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) (or $.Env.HSTS "max-age=31536000") }}
 
+{{/* Use larger proxy buffers only when backend sets PROXY_LARGE_BUFFERS=true (e.g. main app) */}}
+{{ $proxy_large_buffers := eq (or (first (groupByKeys $containers "Env.PROXY_LARGE_BUFFERS")) "false") "true" }}
+
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
@@ -344,6 +347,10 @@ server {
 		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ if $proxy_large_buffers }}
+		proxy_buffer_size 16k;
+		proxy_buffers 8 16k;
+		{{ end }}
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -396,6 +403,10 @@ server {
 		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ if $proxy_large_buffers }}
+		proxy_buffer_size 16k;
+		proxy_buffers 8 16k;
+		{{ end }}
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";


### PR DESCRIPTION
Introduces the ability for a service to opt-in to a larger `proxy_buffer_size` by setting a `PROXY_LARGE_BUFFERS` environment variable on the container.

This allows us to resolve the issue with `er-www` where Nginx throws 502 errors due to the size of the CSP headers.

> [!NOTE]
> This is a replacement for https://github.com/urllo/er-www/pull/305